### PR TITLE
Bundle python-docx for render lambda

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib==2.133.0
 constructs>=10.0.0,<11.0.0
 aws-cognito-identitypool-alpha==2.133.0a0
+aws-cdk.aws-lambda-python-alpha==2.133.0a0

--- a/lambdas/generate_handler/requirements.txt
+++ b/lambdas/generate_handler/requirements.txt
@@ -1,0 +1,1 @@
+python-docx==0.8.11


### PR DESCRIPTION
## Summary
- switch the resume render Lambda to aws_lambda_python_alpha.PythonFunction so dependencies are bundled automatically
- add python-docx as a function dependency and include the Lambda Python alpha construct dependency in the CDK app requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8dd2f9af88323b69432c33ee2359d